### PR TITLE
Fix line continuation for dotnet pack steps in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,10 @@ jobs:
           cp src/MLXSharp.Native/runtimes/osx-arm64/native/libmlxsharp.dylib artifacts/native/
 
       - name: Pack MLXSharp library
-        run: dotnet pack src/MLXSharp/MLXSharp.csproj --configuration Release --output artifacts/packages \
-          -p:MLXSharpMacNativeBinary=$GITHUB_WORKSPACE/native/build/libmlxsharp.dylib
+        run: dotnet pack src/MLXSharp/MLXSharp.csproj --configuration Release --output artifacts/packages -p:MLXSharpMacNativeBinary=$GITHUB_WORKSPACE/native/build/libmlxsharp.dylib
 
       - name: Pack MLXSharp.SemanticKernel library
-        run: dotnet pack src/MLXSharp.SemanticKernel/MLXSharp.SemanticKernel.csproj --configuration Release --output artifacts/packages \
-          -p:MLXSharpMacNativeBinary=$GITHUB_WORKSPACE/native/build/libmlxsharp.dylib
+        run: dotnet pack src/MLXSharp.SemanticKernel/MLXSharp.SemanticKernel.csproj --configuration Release --output artifacts/packages -p:MLXSharpMacNativeBinary=$GITHUB_WORKSPACE/native/build/libmlxsharp.dylib
 
       - name: Verify package contains native libraries
         run: |


### PR DESCRIPTION
## Summary
- remove erroneous line continuations from the dotnet pack steps so MSBuild only receives the intended project argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e229d761248326b7098a2b8b83fdc3